### PR TITLE
Add support to RN >= 0.69 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,21 +189,18 @@ module.exports = {
     ios: {},
     android: {},
   },
-  assets: ['./assets/fonts'],
+  iosAssets: ['./assets/fonts'],
 };
 ```
 
 ### Link
 
 ```sh
+# react-native >= 0.69
+npx react-native-asset 
+
+# otherwise
 react-native link
-```
-
-You can remove assets for android generated with this command, since we are using the XML Font method.
-Otherwise, they would be included twice in the app bundle!
-
-```sh
-rm -rf android/app/src/main/assets/fonts
 ```
 
 ## Result


### PR DESCRIPTION
Excellent guide!

A few changes to keep it up to date: 

- Duplicated assets can be avoided using `iosAssets` instead of `assets`.
- RN version 0.69 replaced `react-native link` with  `npx react-native-asset`

Should fix: https://github.com/jsamr/react-native-font-demo/issues/2